### PR TITLE
Add api endpoint for syncing collections

### DIFF
--- a/app/engine/models.py
+++ b/app/engine/models.py
@@ -47,7 +47,7 @@ class Activity(models.Model):
     collections = models.ManyToManyField(Collection,blank=True)
     knowledge_components = models.ManyToManyField(KnowledgeComponent,blank=True)
     difficulty = models.FloatField(null=True,blank=True)
-    tags = models.TextField(default='')
+    tags = models.TextField(default='',blank=True)
     type = models.CharField(max_length=200, default='')
     # whether to include as valid problem to recommend from adaptive engine
     include_adaptive = models.BooleanField(default=True)

--- a/app/engine/serializers.py
+++ b/app/engine/serializers.py
@@ -67,7 +67,7 @@ class CollectionActivityListSerializer(serializers.ListSerializer):
         # Perform removals from collection.
         for activity_url, activity in activity_mapping.items():
             if activity_url not in data_mapping:
-                activity.remove(self.context['collection'])
+                activity.collections.remove(self.context['collection'])
 
         return results
 

--- a/app/engine/views.py
+++ b/app/engine/views.py
@@ -65,12 +65,14 @@ class CollectionViewSet(viewsets.ModelViewSet):
     def activities(self, request, pk=None):
         collection = self.get_object()
         activities = collection.activity_set.all()
-        serializer = CollectionActivitySerializer(activities, data=request.data, many=True, context={'collection':collection})
         if request.method == 'POST':
+            serializer = CollectionActivitySerializer(activities, data=request.data, many=True, context={'collection':collection})
             if serializer.is_valid():
                 serializer.save()
             else:
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            serializer = CollectionActivitySerializer(activities, many=True, context={'collection':collection})
         return Response(serializer.data)
 
 

--- a/app/engine/views.py
+++ b/app/engine/views.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from rest_framework import viewsets
 from rest_framework import mixins
 from rest_framework.response import Response
-from rest_framework.decorators import list_route
+from rest_framework.decorators import list_route, detail_route
 from rest_framework import status
 from django.http import HttpResponse
 from .serializers import *
@@ -61,6 +61,18 @@ class CollectionViewSet(viewsets.ModelViewSet):
     queryset = Collection.objects.all()
     serializer_class = CollectionSerializer
 
+    @detail_route(methods=['get','post'])
+    def activities(self, request, pk=None):
+        collection = self.get_object()
+        activities = collection.activity_set.all()
+        serializer = CollectionActivitySerializer(activities, data=request.data, many=True, context={'collection':collection})
+        if request.method == 'POST':
+            if serializer.is_valid():
+                serializer.save()
+            else:
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return Response(serializer.data)
+
 
 def is_valid_except_learner_not_found(serializer):
         """
@@ -110,4 +122,3 @@ class ScoreViewSet(viewsets.ModelViewSet):
         
         return Response(serializer.errors,
             status=status.HTTP_400_BAD_REQUEST)
-


### PR DESCRIPTION
Adds API endpoint for synchronizing activities and activity membership in a collection. Endpoint available at /engine/api/collection/<collection_id>/activities.

For POST requests, the endpoint accepts a json-formatted list of activity dict records, which tells the engine that a particular collection is made up of those activities. If activity is not found in the request body, it is removed from the collection (but not necessarily deleted entirely).

For GET requests, no additional parameters are needed and the response returns the list of activities currently in the collection specified in the <collection_id> path parameter.
