### PR TITLE
Add collection grade api endpoint

### DIFF
--- a/app/engine/models.py
+++ b/app/engine/models.py
@@ -14,9 +14,10 @@ class Collection(models.Model):
     def __unicode__(self):
         return "{} - {}".format(self.pk, self.name)
 
-    def grade(self):
+    def grade(self, learner):
         """
-        Generate grade based on masteries that bridge can query
+        Generate learner grade based on masteries that bridge can query
+        as a grading policy option. 
         Just uses a placeholder value for now
         """
         return 0.5

--- a/app/engine/models.py
+++ b/app/engine/models.py
@@ -14,6 +14,13 @@ class Collection(models.Model):
     def __unicode__(self):
         return "{} - {}".format(self.pk, self.name)
 
+    def grade(self):
+        """
+        Generate grade based on masteries that bridge can query
+        Just uses a placeholder value for now
+        """
+        return 0.5
+
 
 class KnowledgeComponent(models.Model):
     name = models.CharField(max_length=200)

--- a/app/engine/views.py
+++ b/app/engine/views.py
@@ -79,8 +79,13 @@ class CollectionViewSet(viewsets.ModelViewSet):
     @detail_route()
     def grade(self, request, pk=None):
         collection = self.get_object()
-        grade = collection.grade()
-        return Response({'grade':grade})
+        try:
+            learner_id = int(request.GET.get('learner',None))
+        except:
+            msg = "Learner id not provided, or not valid"
+            return Response({'message':msg}, status=status.HTTP_400_BAD_REQUEST)
+        grade = collection.grade(learner_id)
+        return Response({'grade':grade, 'learner':learner_id})
 
 
 def is_valid_except_learner_not_found(serializer):

--- a/app/engine/views.py
+++ b/app/engine/views.py
@@ -76,6 +76,12 @@ class CollectionViewSet(viewsets.ModelViewSet):
             serializer = CollectionActivitySerializer(activities, many=True, context={'collection':collection})
         return Response(serializer.data)
 
+    @detail_route()
+    def grade(self, request, pk=None):
+        collection = self.get_object()
+        grade = collection.grade()
+        return Response({'grade':grade})
+
 
 def is_valid_except_learner_not_found(serializer):
         """


### PR DESCRIPTION
Adds api endpoint for bridge to query collection grade for a learner.

Endpoint path: GET /engine/api/collection/<collection_id>/grade
Parameters: learner (int)