### PR TITLE
Update recommend api endpoint

### DIFF
--- a/app/engine/serializers.py
+++ b/app/engine/serializers.py
@@ -94,7 +94,7 @@ class ActivitySerializer(serializers.ModelSerializer):
 class ActivityRecommendationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Activity
-        fields = ('url')
+        fields = ('url',)
 
 
 class ScoreSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Changes recommend api endpoint to reflect recent changes in bridge. The recommend api endpoint 
now requires POST instead of GET request. The json data expected in the request body looks like:
```
{
    learner: <user_id>,
    collection: <collection_id>
    sequence: [ # List of already taken activities
        {
            activity: <source_launch_url>,
            score: <score>,
            is_problem: Bool,
        },
        ....
    ],
}
```
The `sequence` array represents learner's previous activity history in the collection sequence.