### PR TITLE
Knowledge component api

### DIFF
--- a/app/engine/serializers.py
+++ b/app/engine/serializers.py
@@ -184,7 +184,7 @@ class KnowledgeComponentSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = KnowledgeComponent
-        fields = ('kc_id', 'name', 'mastery_prior')
+        fields = ('id', 'kc_id', 'name', 'mastery_prior')
         lookup_field = 'kc_id'  # lookup based on kc_id slug field
 
 


### PR DESCRIPTION
Minor addition to KC api, to include `id` field (corresponding to primary key) in knowledge component representation, to help with data loading. Adds tests for this plus general tests for KC api functionality.