### PR TITLE
Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 sudo: required
 
+language: generic
+
 services:
 - docker
 
-before_install:
+install:
 - cd app
 - docker-compose build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: required
 
-language: generic
-
 services:
 - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: generic
 services:
 - docker
 
-install:
+before_install:
 - cd app
 - docker-compose build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 sudo: required
 
+language: generic
+
 services:
 - docker
 
-before_install:
+install:
 - cd app
 - docker-compose build
+- docker-compose up -d postgres
 
 script:
 - docker-compose run web pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+services:
+- docker
+
+before_install:
+- cd app
+- docker-compose build
+
+script:
+- docker-compose run web pytest

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data/
     ports:
-      - "5432:5432"
+      - "5432"
   web:
     image: engine_app
     build:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.14.0
 requests==2.18.4
 gunicorn==19.7.1
 psycopg2==2.7.4
-alosi==1.0.0
+alosi==1.1.1
 django_extensions==1.9.9
 pandas==0.22.0
 ipykernel==4.8.2


### PR DESCRIPTION
Use Travis CI to run tests. Changed the default docker-compose setup used by travis (docker-compose.yml) to not expose port 5432 to post since that is not allowed in test build. Also updates alosi requirement version to 1.1.1 (due to use of `ApiClient.request()` introduced in 1.1.0, and bug fix in 1.1.1)