### PR TITLE
Add prerequisite activity api

### DIFF
--- a/app/engine/api_v2.py
+++ b/app/engine/api_v2.py
@@ -283,3 +283,19 @@ class ScoreViewSet(viewsets.ModelViewSet):
         log.debug("Triggering engine update from score")
         engine = get_engine()
         engine.update_from_score(score.learner, score.activity, score.score)
+
+
+class PrerequisiteActivityViewSet(viewsets.ModelViewSet):
+    """
+    Prerequisite Activity -related API endpoints
+
+    Standard CRUD endpoints:
+        GET /prerequisite_activity - list
+        POST /prerequisite_activity - create
+        GET /prerequisite_activity/{pk} - retrieve
+        PUT /prerequisite_activity/{pk} - update
+        PATCH /prerequisite_activity/{pk} - partial update
+        DELETE /prerequisite_activity/{pk} - destroy
+    """
+    queryset = Activity.prerequisite_activities.through.objects.all()
+    serializer_class = PrerequisiteActivitySerializer

--- a/app/engine/serializers.py
+++ b/app/engine/serializers.py
@@ -279,3 +279,16 @@ class CollectionActivitySerializer(serializers.ModelSerializer):
         model = Activity
         fields = ('source_launch_url', 'name', 'difficulty', 'tags')
         list_serializer_class = CollectionActivityListSerializer
+
+
+class PrerequisiteActivitySerializer(serializers.ModelSerializer):
+    """
+    Model serializer for Activity.prerequisite_activities.through
+    """
+    class Meta:
+        model = Activity.prerequisite_activities.through
+        # from_activity: dependent activity
+        # to_activity: prerequisite activity
+        fields = ('from_activity','to_activity')
+
+# Activity.prerequisite_activities.through.

--- a/app/engine/urls.py
+++ b/app/engine/urls.py
@@ -10,6 +10,8 @@ router_v2.register('collection', api_v2.CollectionViewSet)
 router_v2.register('score', api_v2.ScoreViewSet)
 router_v2.register('mastery', api_v2.MasteryViewSet)
 router_v2.register('knowledge_component', api_v2.KnowledgeComponentViewSet)
+router_v2.register('prerequisite_activity', api_v2.PrerequisiteActivityViewSet)
+
 
 urlpatterns = [
     path('api/v2/', include(router_v2.urls)),


### PR DESCRIPTION
Adds API endpoints for managing prerequisite activity relationships (via standard DRF model viewset using the `Activity.prerequisite_activities.through` model)

Endpoints:
* GET /prerequisite_activity - list
* POST /prerequisite_activity - create
* GET /prerequisite_activity/{pk} - retrieve
* PUT /prerequisite_activity/{pk} - update
* PATCH /prerequisite_activity/{pk} - partial update
* DELETE /prerequisite_activity/{pk} - destroy

Example POST data:
```
{
    "from_field": 2,    # this is the pk of the dependent activity
    "to_field" : 1      # this is the pk of the prerequisite activity
}
```