### PR TITLE
Add prerequisite activity field to activity api endpoints

### DIFF
--- a/app/engine/serializers.py
+++ b/app/engine/serializers.py
@@ -100,7 +100,8 @@ class ActivitySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Activity
-        fields = ('id', 'collections', 'source_launch_url', 'name', 'difficulty', 'tags', 'knowledge_components')
+        fields = ('id', 'collections', 'source_launch_url', 'name', 'difficulty', 'tags', 'knowledge_components',
+                  'prerequisite_activities')
 
 
 class MasterySerializer(serializers.ModelSerializer):

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -164,3 +164,15 @@ def test_api_create_prerequisite_activity(engine_api, activities):
     )
     r = engine_api.request('POST', 'prerequisite_activity', json=data)
     assert r.ok
+
+@pytest.mark.django_db
+def test_api_create_prerequisite_activity_via_field(engine_api, activities):
+    """
+    Modify prerequisite activity relation via activity field
+    :param engine_api: engine api client
+    :param activities: activity queryset
+    :return:
+    """
+    data = dict(prerequisite_activities=[activities[0].pk])
+    r = engine_api.request('PATCH', 'activity/{}'.format(activities[1].pk), json=data)
+    assert r.ok


### PR DESCRIPTION
Add capability to modify prerequisite activity relations from the `prerequisite_activity` field on the activity api model.