### PR TITLE
Add knowledge component prerequisite api

### DIFF
--- a/app/engine/api_v2.py
+++ b/app/engine/api_v2.py
@@ -299,3 +299,19 @@ class PrerequisiteActivityViewSet(viewsets.ModelViewSet):
     """
     queryset = Activity.prerequisite_activities.through.objects.all()
     serializer_class = PrerequisiteActivitySerializer
+
+
+class PrerequisiteKnowledgeComponentViewSet(viewsets.ModelViewSet):
+    """
+    Prerequisite [knowledge component] related API endpoints
+
+        Standard CRUD endpoints:
+        GET /prerequisite_knowledge_component - list
+        POST /prerequisite_knowledge_component - create
+        GET /prerequisite_knowledge_component/{pk} - retrieve
+        PUT /prerequisite_knowledge_component/{pk} - update
+        PATCH /prerequisite_knowledge_component/{pk} - partial update
+        DELETE /prerequisite_knowledge_component/{pk} - destroy
+    """
+    queryset = PrerequisiteRelation.objects.all()
+    serializer_class = PrerequisiteRelationSerializer

--- a/app/engine/serializers.py
+++ b/app/engine/serializers.py
@@ -291,3 +291,12 @@ class PrerequisiteActivitySerializer(serializers.ModelSerializer):
         # from_activity: dependent activity
         # to_activity: prerequisite activity
         fields = ('id','from_activity','to_activity')
+
+
+class PrerequisiteRelationSerializer(serializers.ModelSerializer):
+    """
+    Model serializer for PrerequisiteRelation
+    """
+    class Meta:
+        model = PrerequisiteRelation
+        fields = ('prerequisite','knowledge_component','value')

--- a/app/engine/urls.py
+++ b/app/engine/urls.py
@@ -11,6 +11,7 @@ router_v2.register('score', api_v2.ScoreViewSet)
 router_v2.register('mastery', api_v2.MasteryViewSet)
 router_v2.register('knowledge_component', api_v2.KnowledgeComponentViewSet)
 router_v2.register('prerequisite_activity', api_v2.PrerequisiteActivityViewSet)
+router_v2.register('prerequisite_knowledge_component', api_v2.PrerequisiteKnowledgeComponentViewSet)
 
 
 urlpatterns = [


### PR DESCRIPTION
API for managing knowledge component prerequisite relations

example data for create:

```
{
    "prerequisite": 1,    # pk of prereq kc
    "knowledge_component": 2,    # pk of dependent kc
    "value": 1.0    # weight on relation
}
```