### PR TITLE
API filtering for mastery endpoint

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -116,4 +116,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+    )
 }

--- a/app/config/settings/local.py
+++ b/app/config/settings/local.py
@@ -4,6 +4,7 @@ SECRET_KEY = 'sp(j(ts6ri()muwz-$^i+k+jgjfv$jbgs@9oq@lzy6x5@lynqd'
 
 INSTALLED_APPS += [
     'django_extensions',
+    'django_filters',
 ]
 
 ALLOWED_HOSTS += ['localhost', 'engine']

--- a/app/engine/api_v2.py
+++ b/app/engine/api_v2.py
@@ -218,6 +218,7 @@ class MasteryViewSet(viewsets.ModelViewSet):
     """
     queryset = Mastery.objects.all()
     serializer_class = MasterySerializer
+    filter_fields = ('learner',)
 
     @action(methods=['put'], detail=False)
     def bulk_update(self, request):

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -11,3 +11,4 @@ ipykernel==4.8.2
 pytest
 pytest-django
 boto3==1.9.29
+django-filter==2.0.0


### PR DESCRIPTION
Uses DRF + django-filter's `DjangoFilterBackend` to provide filtering of mastery API endpoints using the `?learner` query parameter.

Example (with filtering):

url = `http://localhost:8000/api/v2/mastery?learner=1`
response:
```
[
    {
        "learner": {
            "user_id": "learner1",
            "tool_consumer_instance_guid": "example.com"
        },
        "knowledge_component": {
            "kc_id": "kc1"
        },
        "value": 0.4
    }
]
```

Without filtering:

url = `http://localhost:8000/api/v2/mastery`
response:
```
[
    {
        "learner": {
            "user_id": "learner1",
            "tool_consumer_instance_guid": "example.com"
        },
        "knowledge_component": {
            "kc_id": "kc1"
        },
        "value": 0.4
    },
    {
        "learner": {
            "user_id": "learner2",
            "tool_consumer_instance_guid": "example.com"
        },
        "knowledge_component": {
            "kc_id": "kc1"
        },
        "value": 0.3
    }
]
```