### PR TITLE
User id filter for mastery api

### DIFF
--- a/app/engine/api_v2.py
+++ b/app/engine/api_v2.py
@@ -218,7 +218,7 @@ class MasteryViewSet(viewsets.ModelViewSet):
     """
     queryset = Mastery.objects.all()
     serializer_class = MasterySerializer
-    filter_fields = ('learner',)
+    filter_fields = ('learner', 'learner__user_id',)
 
     @action(methods=['put'], detail=False)
     def bulk_update(self, request):


### PR DESCRIPTION
Add ability to filter mastery list api endpoint by learner's string user_id.

Example:

url: `localhost:8000/api/v2/mastery?learner__user_id=learner1`
```
[{'learner': {'user_id': 'learner1',
   'tool_consumer_instance_guid': 'example.com'},
  'knowledge_component': {'kc_id': 'kc1'},
  'value': 0.4}]
```