### PR TITLE
Pagination in list APIs

### DIFF
--- a/app/config/settings/base.py
+++ b/app/config/settings/base.py
@@ -118,5 +118,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
-    )
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
 }

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -115,7 +115,7 @@ def test_knowledge_component_id_field(engine_api, knowledge_component):
     :return:
     """
     r = engine_api.request('GET', 'knowledge_component')  # kc list endpoint
-    assert 'id' in r.json()[0]
+    assert 'id' in r.json()['results'][0]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Uses Limit Offset pagination style: https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination

Default page size is 100.

response format:
```
{
    "count": 1,
    "next": "https://api.example.org/accounts/?limit=100&offset=500",
    "previous": "https://api.example.org/accounts/?limit=100&offset=300",
    "results": [
        {
            "id": 1,
            "collections": [
                1
            ],
            "source_launch_url": "https://example.com/activity/1",
            "name": "my activity 1",
            "difficulty": null,
            "tags": "",
            "knowledge_components": [],
            "prerequisite_activities": []
        },
        ...
    ]
}


```