### PR TITLE
Fix non-existing postgres 'engine' database and wrong container name in docs

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -19,7 +19,7 @@ cd app
 docker-compose up -d
 
 # apply database migrations
-docker-compose run engine python manage.py migrate
+docker-compose run web python manage.py migrate
 ```
 
 The engine should now be available at localhost:8000. Try opening localhost:8000/engine/api in a web browser.
@@ -29,7 +29,7 @@ The engine should now be available at localhost:8000. Try opening localhost:8000
 To access the Django admin panel, a superuser needs to be created.
 ```
 # Open an interactive shell in engine docker container
-docker-compose run engine bash
+docker-compose run web bash
 
 # Create super user account
 python manage.py createsuperuser

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: postgres
     environment:
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: engine
     volumes:
       - pgdata:/var/lib/postgresql/data/
     ports:


### PR DESCRIPTION
When trying to run this application

a) while running
```docker-compose run engine python manage.py migrate```
I encountered this error message:
```ERROR: No such service: engine```

since the Django container is named `web` in `docker-compose.yml` and not `engine`.
This is fixed by renaming the relevant commands in the `app` README.

b) Startup errors (in the docker-compose logs) relating to the postgres database `engine` not existing.

The reason for this is that the `postgres` container creates a DB named `postgres` by default. This pull request resolves that issue by adding `POSTGRES_DB: engine` to `docker-compose.yml`. Please note that I did not add those to all other compose configs like `docker-compose.prod.yml`.

*Note:* If you have already started up the container, `postgres` will not automatically re-initialize. You need to delete the `pgdata` volume using `docker volume rm app_pgdata` **but note that deleting the volume WILL result in loss of all data already being in the database**